### PR TITLE
Add preview of input manager

### DIFF
--- a/crates/dotrix_core/Cargo.toml
+++ b/crates/dotrix_core/Cargo.toml
@@ -9,11 +9,13 @@ license = "MIT"
 # [features]
 
 [dependencies]
-dotrix_ecs = { path = "../dotrix_ecs", version = "0.1.0" }
-wgpu = "0.6"
-winit = "0.23.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+dotrix_ecs = { path = "../dotrix_ecs", version = "0.1.0" }
+strum = "0.19"
+strum_macros = "0.19"
+wgpu = "0.6"
 wgpu-subscriber = "0.1.0"
+winit = "0.23.0"
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }

--- a/crates/dotrix_core/Cargo.toml
+++ b/crates/dotrix_core/Cargo.toml
@@ -11,11 +11,13 @@ license = "MIT"
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["std"] }
 dotrix_ecs = { path = "../dotrix_ecs", version = "0.1.0" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 strum = "0.19"
 strum_macros = "0.19"
 wgpu = "0.6"
 wgpu-subscriber = "0.1.0"
-winit = "0.23.0"
+winit = { version = "0.23.0", features = ["serde"] }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }

--- a/crates/dotrix_core/src/dotrix.rs
+++ b/crates/dotrix_core/src/dotrix.rs
@@ -147,7 +147,10 @@ async fn run(event_loop: EventLoop<()>, window: winit::window::Window, dotrix: &
     let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
 
     let mut input_manager = input::InputManager::new();
-    input_manager.register_default_keymaps();
+    let input_config = input::InputConfig::default();
+    input_manager.initialize(&input_config);
+
+    println!("{}", serde_json::to_string_pretty(&input_manager.create_config()).unwrap());
 
     event_loop.run(move |event, _, control_flow| {
         // Have the closure take ownership of the resources.
@@ -176,7 +179,7 @@ async fn run(event_loop: EventLoop<()>, window: winit::window::Window, dotrix: &
                 swap_chain = device.create_swap_chain(&surface, &sc_desc);
             }
             Event::RedrawRequested(_) => {
-                // TODO: call 
+                // TODO: call
                 // * all systems run cycle
                 // * world.render() here
                 let frame = swap_chain

--- a/crates/dotrix_core/src/dotrix.rs
+++ b/crates/dotrix_core/src/dotrix.rs
@@ -1,4 +1,5 @@
 use crate::{
+    input,
     window::Window,
 };
 
@@ -145,6 +146,9 @@ async fn run(event_loop: EventLoop<()>, window: winit::window::Window, dotrix: &
 
     let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
 
+    let mut input_manager = input::InputManager::new();
+    input_manager.register_default_keymaps();
+
     event_loop.run(move |event, _, control_flow| {
         // Have the closure take ownership of the resources.
         // `event_loop.run` never returns, therefore we must do this to ensure
@@ -158,6 +162,9 @@ async fn run(event_loop: EventLoop<()>, window: winit::window::Window, dotrix: &
         );
 
         *control_flow = ControlFlow::Poll;
+
+        input_manager.update(); // TODO: can winit event loop runs more than once per frame?
+
         match event {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),
@@ -200,6 +207,18 @@ async fn run(event_loop: EventLoop<()>, window: winit::window::Window, dotrix: &
                 event: WindowEvent::CloseRequested,
                 ..
             } => *control_flow = ControlFlow::Exit,
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput{device_id, input, is_synthetic},
+                ..
+            } => input_manager.handle_keyboard_event(device_id, input, is_synthetic),
+            Event::WindowEvent {
+                event: WindowEvent::MouseInput{device_id, state, button, modifiers},
+                ..
+            } => input_manager.handle_mouse_event(device_id, state, button),
+            Event::WindowEvent {
+                event: WindowEvent::MouseWheel{device_id, delta, phase, modifiers},
+                ..
+            } => input_manager.handle_mouse_wheel_event(device_id, delta, phase),
             _ => {}
         }
     });

--- a/crates/dotrix_core/src/input.rs
+++ b/crates/dotrix_core/src/input.rs
@@ -1,5 +1,7 @@
 mod actions;
+mod config;
 mod manager;
 
 pub use actions::*;
+pub use config::*;
 pub use manager::*;

--- a/crates/dotrix_core/src/input.rs
+++ b/crates/dotrix_core/src/input.rs
@@ -1,0 +1,5 @@
+mod actions;
+mod manager;
+
+pub use actions::*;
+pub use manager::*;

--- a/crates/dotrix_core/src/input/actions.rs
+++ b/crates/dotrix_core/src/input/actions.rs
@@ -1,0 +1,14 @@
+use strum_macros::*;
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter)]
+/// All mapable actions
+pub enum Action {
+    Ability1,
+    Ability2,
+    Jump,
+    MoveBackward,
+    MoveForward,
+    MoveLeft,
+    MoveRight,
+    Shoot,
+}

--- a/crates/dotrix_core/src/input/actions.rs
+++ b/crates/dotrix_core/src/input/actions.rs
@@ -1,14 +1,37 @@
+use serde::{Deserialize, Serialize};
 use strum_macros::*;
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter)]
-/// All mapable actions
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter, Serialize, Deserialize, Ord, PartialOrd,)]
+/// All bindable actions
 pub enum Action {
-    Ability1,
-    Ability2,
+    ActionButton1,
+    ActionButton2,
+    ActionButton3,
+    ActionButton4,
+    ActionButton5,
+    ActionButton6,
+    ActionButton7,
+    ActionButton8,
+    ActionButton9,
+    AutoRun,
+    Chat,
     Jump,
     MoveBackward,
     MoveForward,
     MoveLeft,
     MoveRight,
-    Shoot,
+    Sit,
+    TargetNearestEnemy,
+    TargetSelf,
+    ToggleBackpack,
+    ToggleCharacterPanel,
+    ToggleGameMenu,
+    ToggleInventory,
+    ToggleMap,
+    ToggleProfessionBook,
+    ToggleQuestLog,
+    ToggleSpellbook,
+    ToggleTalentPane,
+    ZoomIn,
+    ZoomOut,
 }

--- a/crates/dotrix_core/src/input/config.rs
+++ b/crates/dotrix_core/src/input/config.rs
@@ -1,0 +1,176 @@
+use super::{Action, Button};
+use serde::*;
+use serde::ser::{Serialize, Serializer};
+use std::collections::{BTreeMap, HashMap};
+use strum::IntoEnumIterator;
+use winit::event::{MouseButton, VirtualKeyCode};
+
+#[derive(Deserialize, Serialize, Copy, Clone)]
+pub struct Binding {
+    pub primary: Button,
+    pub secondary: Button,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InputConfig {
+    #[serde(serialize_with = "ordered_map")]
+    pub bindings: HashMap<Action, Binding>,
+}
+
+/// Sort keys and serialize
+fn ordered_map<S>(map: &HashMap<Action, Binding>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let ordered: BTreeMap<_, _> = map.iter().collect();
+    ordered.serialize(serializer)
+}
+
+
+impl InputConfig {
+    /// Default config
+    pub fn default() -> Self {
+        let mut bindings: HashMap<Action, Binding> = HashMap::new();
+
+        for action in Action::iter() {
+            bindings.insert(action, Binding {primary: Button::None, secondary: Button::None});
+        }
+
+        // Set default bindings here
+        bindings.insert(
+            Action::ActionButton1,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Key1),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ActionButton2,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Key2),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ActionButton3,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Key3),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ActionButton4,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Key4),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ActionButton5,
+            Binding {
+                primary: Button::Mouse(MouseButton::Other(1)),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ActionButton6,
+            Binding {
+                primary: Button::Mouse(MouseButton::Other(2)),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::AutoRun,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Numlock),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::Chat,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Return),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::Jump,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Space),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::TargetSelf,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::F1),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::TargetNearestEnemy,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::Tab),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::MoveBackward,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::S),
+                secondary: Button::Key(VirtualKeyCode::Down),
+            },
+        );
+        bindings.insert(
+            Action::MoveForward,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::W),
+                secondary: Button::Key(VirtualKeyCode::Up),
+            },
+        );
+        bindings.insert(
+            Action::MoveLeft,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::A),
+                secondary: Button::Key(VirtualKeyCode::Left),
+            },
+        );
+        bindings.insert(
+            Action::MoveRight,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::D),
+                secondary: Button::Key(VirtualKeyCode::Right),
+            },
+        );
+        bindings.insert(
+            Action::ToggleBackpack,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::B),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ToggleCharacterPanel,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::C),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ToggleInventory,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::I),
+                secondary: Button::None,
+            },
+        );
+        bindings.insert(
+            Action::ToggleMap,
+            Binding {
+                primary: Button::Key(VirtualKeyCode::M),
+                secondary: Button::None,
+            },
+        );
+
+        return Self { bindings };
+    }
+}

--- a/crates/dotrix_core/src/input/manager.rs
+++ b/crates/dotrix_core/src/input/manager.rs
@@ -1,0 +1,142 @@
+use super::Action;
+use std::{collections::HashMap};
+use strum::IntoEnumIterator;
+use winit::{event::{DeviceId, ElementState, KeyboardInput, MouseButton, MouseScrollDelta, TouchPhase}};
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+/// Key or button
+pub enum KeyTrigger{
+    Key{scancode: u32},
+    MouseButton{button: MouseButton},
+    None,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+enum KeyState {
+    None,
+    Pressed,
+    Hold,
+    Released,
+}
+
+/// Manager for input
+pub struct InputManager {
+    /// Mapped keys
+    input_map: HashMap<KeyTrigger, Action>,
+    /// Current state of actions
+    key_states: HashMap<Action, KeyState>,
+    /// Mouse Scrolling, value should be between -1 and 1 (but should be smaller on higher, depends on OS and device)
+    scroll_delta: f32,
+}
+
+impl InputManager {
+    pub fn new() -> Self {
+        Self {
+            input_map: HashMap::new(),
+            key_states: HashMap::new(),
+            scroll_delta: 0.0,
+        }
+    }
+
+    /// Initialization
+    pub fn register_default_keymaps(&mut self) {
+        // Set key maps and states to default values
+        for key_action in Action::iter() {
+            self.input_map.insert(KeyTrigger::None, key_action);
+            self.key_states.insert(key_action, KeyState::None);
+        }
+
+        // Map some keys on keyboard
+        self.input_map.insert(KeyTrigger::Key{scancode: 57}, Action::Jump); // Space
+        self.input_map.insert(KeyTrigger::Key{scancode: 17}, Action::MoveForward); // W
+        self.input_map.insert(KeyTrigger::Key{scancode: 31}, Action::MoveBackward); // S
+        self.input_map.insert(KeyTrigger::Key{scancode: 30}, Action::MoveLeft); // A
+        self.input_map.insert(KeyTrigger::Key{scancode: 32}, Action::MoveRight); // D
+
+         // Map some keys on mouse
+        self.input_map.insert(KeyTrigger::MouseButton{button: MouseButton::Left}, Action::Shoot); // LMB
+        self.input_map.insert(KeyTrigger::MouseButton{button: MouseButton::Other(1)}, Action::Ability1); // If someone has additional buttons on mouse
+        self.input_map.insert(KeyTrigger::MouseButton{button: MouseButton::Other(2)}, Action::Ability2);
+    }
+
+    /// Return true when button is pressed
+    pub fn get_button_down(&self, key: Action) -> bool {
+        return self.key_states.get(&key).unwrap() == &KeyState::Pressed;
+    }
+
+    /// Return true when button is released
+    pub fn get_button_up(&self, key: Action) -> bool {
+        return self.key_states.get(&key).unwrap() == &KeyState::Released;
+    }
+
+    /// Return true button is pressed or hold
+    pub fn get_button(&self, key: Action) -> bool {
+        let state = self.key_states.get(&key).unwrap();
+        return state == &KeyState::Pressed || state == &KeyState::Hold;
+    }
+
+    /// Returns mouse scroll delta. Value should be between -1 and 0 (but should be smaller on higher, depends on OS and device)
+    pub fn get_scroll(&self) -> f32 {
+        self.scroll_delta
+    }
+
+    /// Update must run before winit event loop
+    pub fn update(&mut self) {
+        for state in self.key_states.iter_mut() {
+            match state.1 {
+                KeyState::Released => {*state.1 = KeyState::None},
+                KeyState::Pressed => {println!("Hold {:?} - updates every frame", &state.0); *state.1 = KeyState::Hold},
+                _ => {}
+            }
+        }
+
+        self.scroll_delta = 0.0;
+    }
+
+    /// Handle mouse event from winit
+    pub fn handle_mouse_event(&mut self, _device_id: DeviceId, state: ElementState, button: MouseButton) {
+        if !self.handle_key_trigger(KeyTrigger::MouseButton{button}, state){
+            println!("{0:?} unmapped {1:?}", state, button);
+        }
+    }
+
+    /// Handle mouse wheel event from winit
+    pub fn handle_mouse_wheel_event(&mut self, _device_id: DeviceId, delta: MouseScrollDelta, _phase: TouchPhase) {
+        match delta {
+            MouseScrollDelta::LineDelta(x, y) => {self.scroll_delta = y; println!("scroll {:?}", y)}, // TODO: clamp between -1 and 1?
+            _ => {println!("unmapped {:?}", delta)}
+        }
+    }
+
+    /// Handle keyboard event from winit
+    pub fn handle_keyboard_event(&mut self, _device_id: DeviceId, input: KeyboardInput, _is_synthetic: bool) {
+        if !self.handle_key_trigger(KeyTrigger::Key{scancode: input.scancode}, input.state) {
+            println!("{0:?} unmapped {1:?} {2:?}", input.state, input.scancode, input.virtual_keycode);
+        }
+
+    }
+
+    pub fn handle_key_trigger(&mut self, key: KeyTrigger, state: ElementState) -> bool {
+        if self.input_map.contains_key(&key) {
+            let action = self.input_map[&key];
+
+            match state {
+                ElementState::Pressed => {
+                    match self.key_states[&action] {
+                        KeyState::None => {
+                            println!("Press {:?}", &action);
+                            self.key_states.insert(action, KeyState::Pressed);
+                        },
+                        _ => {}
+                    }
+                }
+                ElementState::Released => {
+                    println!("Release {:?}", &action);
+                    self.key_states.insert(action, KeyState::Released);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/crates/dotrix_core/src/lib.rs
+++ b/crates/dotrix_core/src/lib.rs
@@ -1,11 +1,10 @@
 mod dotrix;
 
 pub mod asset;
+pub mod input;
 pub mod renderer;
 pub mod window;
 
 pub use dotrix::{
     Dotrix,
 };
-
-

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,30 @@
+use dotrix::{Dotrix, window::Window};
+
+fn main() {
+    /*
+    // look into crates\dotrix_core\src\input\input.rs
+
+    // Example of use:
+
+    let jump = input.get_button_down(InputAction::Jump);
+    let shoot = input.get_button(InputAction::Jump);
+    let zoom = input.get_scroll();
+
+    if jump {
+        println!("character jumped");
+    }
+    if shoot {
+        println!("shooting every frame")
+    }
+    if zoom > 0.0{
+        println!("zoom-in");
+    }
+    if zoom < 0.0 {
+        println!("zoom-out");
+    }
+    */
+
+    Dotrix::init()
+        .window(Window {})
+        .run();
+}

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -2,19 +2,21 @@ use dotrix::{Dotrix, window::Window};
 
 fn main() {
     /*
-    // look into crates\dotrix_core\src\input\input.rs
-
+    * Add new Input action
+    * 1) Register action in 'crates\dotrix_core\src\input\manager.rs'
+    * 2) (optional) Bind action to key 'crates\dotrix_core\src\input\config.rs'
+    * Done
+    *
+    *
     // Example of use:
-
-    let jump = input.get_button_down(InputAction::Jump);
-    let shoot = input.get_button(InputAction::Jump);
-    let zoom = input.get_scroll();
-
+    let jump = input_manager.get_button_down(input::Action::Jump);
+    let forward = input_manager.get_button(input::Action::MoveForward);
+    let zoom = input_manager.get_scroll();
     if jump {
         println!("character jumped");
     }
-    if shoot {
-        println!("shooting every frame")
+    if forward {
+        println!("moving forward");
     }
     if zoom > 0.0{
         println!("zoom-in");
@@ -22,6 +24,7 @@ fn main() {
     if zoom < 0.0 {
         println!("zoom-out");
     }
+
     */
 
     Dotrix::init()


### PR DESCRIPTION
cargo run --example input --release
InputManager logs known mapped actions and unknown keys

**supports:**
- keyboard
- mouse buttons (additional buttons too)
- mouse wheel (or touchpad)

**problems:**
- looks like winit does not support gamepad
- We should decide if we need axis. Unity and UE supports input axis. It's mostly used for gamepads
https://docs.unity3d.com/ScriptReference/Input.GetAxis.html

- **main problem: should we use scancode or virtual_keycode for keyboard?**

ScanCode work for all keys no matter what language is used but don't we know what is the key that user pressed, this would be problem in keymapping GUI.
VirtualCode not work for all keys, for example for czech ú)ů§

Scancode - Identifies the physical key pressed
This should not change if the user adjusts the host's keyboard map. Use when the physical location of the key is more important than the key's host GUI semantics, such as for movement controls in a first-person game.

VirtualCode - Identifies the semantic meaning of the key
Use when the semantics of the key are more important than the physical location of the key, such as when implementing appropriate behavior for "page up."

**IntputManager is using scancode now. I think we should switch to VirtualCode or maybe use combination of both**