### PR TITLE
update winit to version 0.24 to allow building on mac m1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
 dependencies = [
  "bitflags",
  "block",
@@ -2621,9 +2621,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bc559da567d8aa671bbcd08304d49e982c7bf2cb91e10288b9188931c1b772"
+checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
 dependencies = [
  "bitflags",
  "cocoa",

--- a/dotrix_core/Cargo.toml
+++ b/dotrix_core/Cargo.toml
@@ -54,7 +54,7 @@ features = ["trace"]
 version = "0.1.0"
 
 [dependencies.winit]
-version = "0.23.0"
+version = "0.24.0"
 features = ["serde"]
 
 # Optional dependencies

--- a/dotrix_core/src/input.rs
+++ b/dotrix_core/src/input.rs
@@ -31,7 +31,7 @@ pub enum Button {
     /// Middle mouse button
     MouseMiddle,
     /// Mouse button by the code
-    MouseOther(u8),
+    MouseOther(u16),
 }
 
 /// State of a button


### PR DESCRIPTION
Winit 0.23 doesn't compile on a Mac M1 because of this issue: https://github.com/rust-windowing/winit/issues/1782

I changed the version to 0.24 and also changed the `MouseOther(u8)` to `MouseOther(u16)`, because winit now contains a u16 here and I didn't want to downcast it in `on_mouse_click_event`.