### PR TITLE
Fix incorrect screen size information

### DIFF
--- a/dotrix_core/src/window.rs
+++ b/dotrix_core/src/window.rs
@@ -269,10 +269,9 @@ impl Window {
 
     /// Returns the resolution of monitor on which the window currently resides.
     pub fn screen_size(&self) -> Vec2u {
-        // let monitor = self.get().current_monitor().expect(NOT_SUPPORTED_ERROR);
-        //let size = monitor.size();
-        //Vec2u { x: size.width, y: size.height }
-        Vec2u { x: 1920, y: 1080 }
+        let monitor = self.get().current_monitor().expect(NOT_SUPPORTED_ERROR);
+        let size = monitor.size();
+        Vec2u { x: size.width, y: size.height }
     }
 
     /// Change whether or not the window will always be on top of other windows.


### PR DESCRIPTION
There was incorrect information about screen size.
(Error due to big refactoring)

![screen-size](https://user-images.githubusercontent.com/72392311/136668052-2aabe418-596c-4b32-883e-44ec43acf25a.png)
