### PR TITLE
Add states stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "dotrix"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "dotrix_core",
  "dotrix_egui",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "dotrix_core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.13.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotrix"
-version = "0.5.2"
+version = "0.5.3"
 authors = [
   "Elias Kartashov <elias@lowenware.com>",
   "Štěpán Wünsch <sw@lowenware.com>",
@@ -85,6 +85,10 @@ path = "examples/animation/main.rs"
 [[example]]
 name = "light"
 path = "examples/light/main.rs"
+
+[[example]]
+name = "states"
+path = "examples/states/main.rs"
 
 [[example]]
 name = "skybox"

--- a/dotrix_core/Cargo.toml
+++ b/dotrix_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotrix_core"
-version = "0.5.2"
+version = "0.5.3"
 authors = [
   "Elias Kartashov <elias@lowenware.com>",
   "Štěpán Wünsch <sw@lowenware.com>",

--- a/dotrix_core/src/lib.rs
+++ b/dotrix_core/src/lib.rs
@@ -11,6 +11,7 @@ mod globals;
 mod id;
 mod pipeline;
 mod pose;
+mod state;
 mod world;
 
 pub mod animation;
@@ -35,10 +36,11 @@ pub use id::Id;
 pub use pipeline::Pipeline;
 pub use pose::Pose;
 pub use transform::Transform;
-pub use ecs::{ System, Priority, RunLevel };
+pub use ecs::{ System, Priority, RunLevel, StateId };
 pub use input::Input;
 pub use ray::Ray;
 pub use renderer::Renderer;
+pub use state::State;
 pub use window::{ Window, Monitor, VideoMode };
 pub use world::World;
 
@@ -113,6 +115,8 @@ impl Dotrix {
         app.add_service(globals::Globals::default());
         // Render manager
         app.add_service(renderer::Renderer::default());
+        // States stack 
+        app.add_service(state::State::default());
 
         // Window manager
         app.add_service(window::Window::default());

--- a/dotrix_core/src/state.rs
+++ b/dotrix_core/src/state.rs
@@ -1,0 +1,179 @@
+use std::any::Any;
+use crate::ecs::{ Rule, StateId };
+
+struct Entry {
+    state_id: StateId,
+    name: String,
+    boxed: Box<dyn IntoState>,
+}
+
+/// Application States stack service
+pub struct State {
+    stack: Vec<Entry>,
+    state_ptr: usize,
+}
+
+impl State {
+    /// Sets pointer to data, holding information about the application state
+    pub(crate) fn set_pointer(&mut self, state_ptr: usize) {
+        self.state_ptr = state_ptr;
+    }
+
+    fn write_pointer(&self, value: StateId) {
+        let state_ptr = self.state_ptr as *const StateId;
+        if !state_ptr.is_null() {
+            unsafe {
+                *(self.state_ptr as *mut StateId) = value;
+            }
+        }
+    }
+
+    /// Returns a rule, so the system will run when the state is ON
+    pub fn on<T: IntoState>() -> Rule {
+        let state_id = StateId::of::<T>();
+        Rule::StateOn(state_id)
+    }
+
+    /// Returns a rule, so the system will run when the state is OFF
+    pub fn off<T: IntoState>() -> Rule {
+        Rule::StateOff(StateId::of::<T>())
+    }
+
+    /// Pushes the application state to the stack
+    pub fn push<T>(&mut self, state: T)
+    where T: IntoState {
+        let state_id = StateId::of::<T>();
+        let name = String::from(std::any::type_name::<T>());
+        self.stack.push(
+            Entry {
+                state_id,
+                name,
+                boxed: Box::new(state)
+            }
+        );
+        self.write_pointer(state_id);
+    }
+
+    /// Pops the application state from the stack, and returns it
+    pub fn pop<T: IntoState>(&mut self) -> Option<T> {
+        self.pop_any().map(|boxed| {
+            if boxed.is::<T>() {
+                unsafe {
+                    let raw: *mut dyn IntoState = Box::into_raw(boxed);
+                    Some(*Box::from_raw(raw as *mut T))
+                }
+            } else {
+                None
+            }
+        }).unwrap_or(None)
+    }
+
+    /// Pops the application state from the stack, but do not downcast it
+    pub fn pop_any(&mut self) -> Option<Box<dyn IntoState>> {
+        let last = self.stack.pop();
+        let state_id = self.stack.last().map(|entry| entry.state_id)
+            .unwrap_or_else(StateId::of::<bool>);
+        self.write_pointer(state_id);
+        last.map(|entry| entry.boxed)
+    }
+
+    /// Returns a referrence to the current state
+    pub fn get<T: IntoState>(&mut self) -> Option<&T> {
+        self.stack.last()
+            .map(|entry| entry.boxed.downcast_ref())
+            .unwrap_or(None)
+    }
+
+    /// Returns a mutable referrence to the current state
+    pub fn get_mut<T: IntoState>(&mut self) -> Option<&mut T> {
+        self.stack.last_mut()
+            .map(|entry| entry.boxed.downcast_mut())
+            .unwrap_or(None)
+    }
+
+    /// Returns [`StateId`] of current state
+    pub fn id(&self) -> Option<StateId> {
+        self.stack.last().map(|entry| entry.state_id)
+    }
+
+    /// Returns dump of current stack
+    pub fn dump(&self) -> Vec<&str> {
+        self.stack.iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>()
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            stack: Vec::new(),
+            state_ptr: 0
+        }
+    }
+}
+
+/// Application state abstraction
+pub trait IntoState: Any + Send + Sync + 'static {}
+impl<T: 'static + Send + Sync> IntoState for T { }
+
+impl dyn IntoState {
+
+    /// Casts down the reference
+    #[inline]
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        if self.is::<T>() {
+            unsafe { Some(&*(self as *const dyn IntoState as *const T)) }
+        } else {
+            None
+        }
+    }
+
+    /// Casts down the mutual reference
+    #[inline]
+    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
+        if self.is::<T>() {
+            unsafe { Some(&mut *(self as *mut dyn IntoState as *mut T)) }
+        } else {
+            None
+        }
+    }
+
+    /// Checks if the reference is of specific type
+    #[inline]
+    fn is<T: Any>(&self) -> bool {
+        std::any::TypeId::of::<T>() == self.type_id()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct SimpleState {}
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct StateWithData(u32);
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct StateWithAllocation(String);
+
+    #[test]
+    fn state_stack_and_downcasting() {
+        let mut state = State::default();
+
+        state.push(SimpleState {});
+        state.push(StateWithData(123));
+        state.push(StateWithAllocation(String::from("Allocated string")));
+
+        let last: StateWithAllocation = state.pop().unwrap();
+        assert_eq!(last, StateWithAllocation(String::from("Allocated string")));
+
+        let last: StateWithData = state.pop().unwrap();
+        assert_eq!(last, StateWithData(123));
+
+        let last: SimpleState = state.pop().unwrap();
+        assert_eq!(last, SimpleState {});
+    }
+}

--- a/dotrix_overlay/src/lib.rs
+++ b/dotrix_overlay/src/lib.rs
@@ -239,3 +239,4 @@ pub fn extension(application: &mut Application) {
     application.add_system(System::from(render).with(Priority::Custom(0)));
     application.add_service(Overlay::default());
 }
+

--- a/examples/states/main.rs
+++ b/examples/states/main.rs
@@ -1,0 +1,196 @@
+use dotrix::prelude::*;
+use dotrix::{
+    Assets,
+    Frame,
+    Input,
+    World,
+    CubeMap,
+    Pipeline,
+    State,
+};
+use dotrix::egui::{ self, Egui };
+use dotrix::camera;
+use dotrix::input::{ ActionMapper, Button, KeyCode, Mapper };
+use dotrix::overlay::{ self, Overlay };
+use dotrix::sky::{ skybox, SkyBox };
+
+/// In main state you can rotate camera and see FPS counter
+struct MainState {
+    name: String,
+}
+
+/// In paused state you can't rotate camera
+struct PauseState {
+    name: String,
+    handled: bool,
+}
+
+fn main() {
+
+    Dotrix::application("Dotrix: Demo Example")
+        .with(System::from(startup))
+
+        .with(
+            System::from(ui_main)
+                .with(State::off::<PauseState>())
+        )
+        .with(
+            System::from(ui_paused)
+                .with(State::on::<PauseState>())
+        )
+        .with(
+            // Camera control should work only in Main state
+            System::from(camera::control)
+                .with(State::on::<MainState>())
+        )
+
+        .with(overlay::extension)
+        .with(egui::extension)
+        .with(skybox::extension)
+
+        .run();
+}
+
+/// Initial game routines
+fn startup(
+    mut assets: Mut<Assets>,
+    mut input: Mut<Input>,
+    mut state: Mut<State>,
+    mut world: Mut<World>,
+) {
+    // Push main state
+    state.push(MainState {
+        name: String::from("Main state")
+    });
+
+    input.set_mapper(Box::new(Mapper::<Action>::new()));
+
+    // Import skybox textures
+    assets.import("assets/skybox-day/skybox_right.png");
+    assets.import("assets/skybox-day/skybox_left.png");
+    assets.import("assets/skybox-day/skybox_top.png");
+    assets.import("assets/skybox-day/skybox_bottom.png");
+    assets.import("assets/skybox-day/skybox_back.png");
+    assets.import("assets/skybox-day/skybox_front.png");
+
+    // Spawn skybox
+    world.spawn(Some((
+        SkyBox {
+            view_range: 500.0,
+            ..Default::default()
+        },
+        CubeMap {
+            right: assets.register("skybox_right"),
+            left: assets.register("skybox_left"),
+            top: assets.register("skybox_top"),
+            bottom: assets.register("skybox_bottom"),
+            back: assets.register("skybox_back"),
+            front: assets.register("skybox_front"),
+            ..Default::default()
+        },
+        Pipeline::default()
+    )));
+
+    // Map Escape key to Pause the game
+    input.mapper_mut::<Mapper<Action>>()
+        .set(vec![
+            (Action::TogglePause, Button::Key(KeyCode::Escape)),
+        ]);
+}
+
+/// Enumeration of actions provided by the game
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+enum Action {
+    TogglePause,
+}
+
+fn ui_main(
+    mut state: Mut<State>,
+    input: Const<Input>,
+    overlay: Const<Overlay>,
+    frame: Const<Frame>
+) {
+    let egui_overlay = overlay.get::<Egui>()
+        .expect("Egui overlay must be added on startup");
+
+    let main_state = state.get::<MainState>().expect("The system to be run in main state");
+
+    if input.is_action_activated(Action::TogglePause) {
+        state.push(
+            PauseState {
+                name: String::from("Paused State"),
+                handled: false,
+            }
+        );
+        return;
+    }
+
+    egui::Area::new("Info label")
+        .fixed_pos(egui::pos2(16.0, 16.0))
+        .show(&egui_overlay.ctx, |ui| {
+            ui.colored_label(
+                egui::Rgba::from_rgb(255.0, 255.0, 255.0),
+                format!("Press ESC to exit {} and pause", main_state.name)
+            );
+        });
+
+    egui::Area::new("FPS counter")
+        .fixed_pos(egui::pos2(16.0, 32.0))
+        .show(&egui_overlay.ctx, |ui| {
+            ui.colored_label(
+                egui::Rgba::from_rgb(255.0, 255.0, 255.0),
+                format!("FPS: {:.1}", frame.fps())
+            );
+        });
+}
+
+fn ui_paused(
+    mut state: Mut<State>,
+    input: Const<Input>,
+    overlay: Const<Overlay>,
+) {
+    let egui_overlay = overlay.get::<Egui>()
+        .expect("Egui overlay must be added on startup");
+
+    let states_stack_dump = state.dump().join(",\n  ");
+
+    let mut pause_state = state.get_mut::<PauseState>()
+        .expect("The system to be run in pause state");
+
+    let mut exit_state = pause_state.handled && input.is_action_activated(Action::TogglePause);
+    pause_state.handled = true;
+
+    egui::containers::Window::new("Paused")
+        .resizable(false)
+        .default_width(200.0)
+        .show(&egui_overlay.ctx, |ui| {
+            ui.label("Execution is paused. Camera is not controllable");
+            ui.label(format!("Current states stack: [\n  {}\n]", states_stack_dump));
+            if ui.button("Resume").clicked() {
+                exit_state = true;
+            }
+        });
+
+    egui::Area::new("Info label")
+        .fixed_pos(egui::pos2(16.0, 16.0))
+        .show(&egui_overlay.ctx, |ui| {
+            ui.colored_label(
+                egui::Rgba::from_rgb(255.0, 255.0, 255.0),
+                format!("Press ESC to exit {} and resume", pause_state.name)
+            );
+        });
+
+    if exit_state {
+        state.pop_any();
+    }
+}
+
+
+/// Bind Inputs and Actions
+impl ActionMapper<Action> for Input {
+    fn action_mapped(&self, action: Action) -> Option<&Button> {
+        let mapper = self.mapper::<Mapper<Action>>();
+        mapper.get_button(action)
+    }
+}
+


### PR DESCRIPTION
This PR implements application states stack.

Developer can define rules on what states what systems should run. By default any system runs on any state.

States are identified by data types and can be structure with or without data:
```
struct MainState {
    name: String,
}

struct PauseState {
    name: String,
    handled: bool,
}
```

This will add rule to enable system only when `MainState` is active
```
.with(
    System::from(camera::control)
        .with(State::on::<MainState>())
)
```

There could be more rules in fact:
```
.with(
    System::from(player::control)
        .with(State::on::<MainState>())
        .with(State::on::<InventoryState>())
)
```

It is also possible to enable on all but some states:
```
.with(
    System::from(ui_main)
        .with(State::off::<PauseState>())
)
```

There is a new service `State` that implements API to control the state of application:
```
fn startup(
    mut state: Mut<State>,
) {
    // Push main state
    state.push(MainState {
        name: String::from("Main state")
    });
}
```

When you need, you can return to previous state:

```
fn system_where_you_pop_the_state (
    mut state: Mut<State>,
) {
   ....
    if exit_state {
        state.pop_any();
    }
}