### PR TITLE
Expose egui::Ui which was hidden by overlay::Ui

### DIFF
--- a/dotrix_egui/src/lib.rs
+++ b/dotrix_egui/src/lib.rs
@@ -19,7 +19,7 @@ use dotrix_core::{Application, Assets, Id, Input, Pipeline, Window};
 
 use dotrix_overlay::{Overlay, Ui, Widget};
 
-pub use egui::*;
+pub use egui::{self, *};
 
 const TEXTURE_NAME: &str = "egui::texture";
 const SCROLL_SENSITIVITY: f32 = 10.0;

--- a/dotrix_egui/src/lib.rs
+++ b/dotrix_egui/src/lib.rs
@@ -19,7 +19,7 @@ use dotrix_core::{Application, Assets, Id, Input, Pipeline, Window};
 
 use dotrix_overlay::{Overlay, Ui, Widget};
 
-pub use egui::{self, *};
+pub use egui::{self as native, *};
 
 const TEXTURE_NAME: &str = "egui::texture";
 const SCROLL_SENSITIVITY: f32 = 10.0;


### PR DESCRIPTION
This was an odd one. I was doing some Ui on my game and found that I needed a function that could take `egui::Ui` as input. Went ahead and imported it via `dotrix::egui::Ui` but got this:

```rust
error[E0603]: trait `Ui` is private
  --> src/gui/mod.rs:6:26
   |
6  | use dotrix::egui::{Egui, Ui};
   |                          ^^ private trait
   |
note: the trait `Ui` is defined here
  --> dotrix/dotrix_egui/src/lib.rs:20:31
   |
20 | use dotrix_overlay::{Overlay, Ui, Widget};
   |                               ^^

For more information about this error, try `rustc --explain E0603`.
error: could not compile `innermind` due to previous error
```

The overlay::Ui is hiding it.

---

This PR

- exposes `dotrix::egui::egui`

Which ensures that all of egui is avaliable under a unique path in addition in case we have any more name clashes.


Alternativly we could add things like `pub use egui::Ui as EguiUi` when needed but we make run into issues with this again if add another similarly named object