### PR TITLE
Force wgpu to use High Performance GPU

### DIFF
--- a/dotrix_core/src/renderer/backend.rs
+++ b/dotrix_core/src/renderer/backend.rs
@@ -207,7 +207,7 @@ pub(crate) async fn init(window: &winit::window::Window) -> Context {
     let surface = unsafe { instance.create_surface(window) };
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::default(),
+            power_preference: wgpu::PowerPreference::HighPerformance,
             // Request an adapter which can render to our surface
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,


### PR DESCRIPTION
Getting adapter from wgpu using `wgpu::PowerPreference::default()` returns `wgpu::PowerPreference::LowPower`.

This PR changes it.
Nobody wants to game on integrated GPU.
This change increased my performance 6x on `compute` example.