### PR TITLE
Fix ProjView matrix loading system run level

### DIFF
--- a/dotrix_core/src/camera.rs
+++ b/dotrix_core/src/camera.rs
@@ -126,7 +126,7 @@ pub fn startup(mut globals: Mut<Globals>) {
 }
 
 /// Loads the ProjView binding with current matrix value
-pub fn bind(
+pub fn load(
     mut globals: Mut<Globals>,
     mut camera: Mut<Camera>,
     renderer: Const<Renderer>,

--- a/dotrix_core/src/ecs.rs
+++ b/dotrix_core/src/ecs.rs
@@ -68,17 +68,19 @@ pub struct System {
 /// Defines when and how often a system should run.
 #[derive(Debug, Eq, PartialEq)]
 pub enum RunLevel {
-    /// Only once on application startup
+    /// One time execution on application startup
     Startup,
-    /// Begin of rendering request handling
+    /// Execution on the beginning of each frame
     Bind,
-    /// Before rendering stage
-    Standard,
-    /// Rendering stage
+    /// Execution on every frame for most of the calculations and updates (Default)
+    Update,
+    /// Execution on every frame to load data to GPU buffers right before rendering
+    Load,
+    /// Execution on every frame to submit rendering passes
     Render,
-    /// End of the rendering request handling
+    /// Execution everytime after a frame was rendered
     Release,
-    /// Execution after window resizing
+    /// One-time execution after window resizing
     Resize,
 }
 
@@ -88,6 +90,8 @@ impl From<&str> for RunLevel {
             RunLevel::Startup
         } else if name.ends_with("::bind") {
             RunLevel::Bind
+        } else if name.ends_with("::load") {
+            RunLevel::Load
         } else if name.ends_with("::render") {
             RunLevel::Render
         } else if name.ends_with("::release") {
@@ -95,7 +99,7 @@ impl From<&str> for RunLevel {
         } else if name.ends_with("::resize") {
             RunLevel::Resize
         } else {
-            RunLevel::Standard
+            RunLevel::Update
         }
     }
 }
@@ -460,6 +464,7 @@ mod tests {
 
     fn startup(_service: Const<MyService>) {}
     fn bind(_service: Const<MyService>) {}
+    fn load(_service: Const<MyService>) {}
     fn render(_service: Const<MyService>) {}
     fn release(_service: Const<MyService>) {}
     fn resize(_service: Const<MyService>) {}
@@ -472,6 +477,9 @@ mod tests {
         let system = System::from(bind);
         assert_eq!(system.run_level, RunLevel::Bind);
 
+        let system = System::from(load);
+        assert_eq!(system.run_level, RunLevel::Load);
+
         let system = System::from(render);
         assert_eq!(system.run_level, RunLevel::Render);
 
@@ -482,6 +490,6 @@ mod tests {
         assert_eq!(system.run_level, RunLevel::Resize);
 
         let system = System::from(my_system_with_context);
-        assert_eq!(system.run_level, RunLevel::Standard);
+        assert_eq!(system.run_level, RunLevel::Update);
     }
 }

--- a/dotrix_core/src/ecs.rs
+++ b/dotrix_core/src/ecs.rs
@@ -76,6 +76,8 @@ pub enum RunLevel {
     Update,
     /// Execution on every frame to load data to GPU buffers right before rendering
     Load,
+    /// Execution on every frame to submit compute passes
+    Compute,
     /// Execution on every frame to submit rendering passes
     Render,
     /// Execution everytime after a frame was rendered
@@ -92,6 +94,8 @@ impl From<&str> for RunLevel {
             RunLevel::Bind
         } else if name.ends_with("::load") {
             RunLevel::Load
+        } else if name.ends_with("::compute") {
+            RunLevel::Compute
         } else if name.ends_with("::render") {
             RunLevel::Render
         } else if name.ends_with("::release") {
@@ -465,6 +469,7 @@ mod tests {
     fn startup(_service: Const<MyService>) {}
     fn bind(_service: Const<MyService>) {}
     fn load(_service: Const<MyService>) {}
+    fn compute(_service: Const<MyService>) {}
     fn render(_service: Const<MyService>) {}
     fn release(_service: Const<MyService>) {}
     fn resize(_service: Const<MyService>) {}
@@ -482,6 +487,9 @@ mod tests {
 
         let system = System::from(render);
         assert_eq!(system.run_level, RunLevel::Render);
+
+        let system = System::from(compute);
+        assert_eq!(system.run_level, RunLevel::Compute);
 
         let system = System::from(release);
         assert_eq!(system.run_level, RunLevel::Release);

--- a/dotrix_core/src/lib.rs
+++ b/dotrix_core/src/lib.rs
@@ -128,7 +128,7 @@ impl Dotrix {
         // Recalculate FPS and delta time
         app.add_system(System::from(frame::bind));
         // load proj_view matrices
-        app.add_system(System::from(camera::bind));
+        app.add_system(System::from(camera::load));
 
         // Calculate skeletal animations
         app.add_system(System::from(animation::skeletal));

--- a/dotrix_pbr/src/lib.rs
+++ b/dotrix_pbr/src/lib.rs
@@ -21,7 +21,7 @@ pub use model::Model;
 pub fn extension(app: &mut Application) {
     app.add_system(System::from(material::startup));
     app.add_system(System::from(light::startup));
-    app.add_system(System::from(light::bind));
+    app.add_system(System::from(light::load));
 
     solid::extension(app);
     skeletal::extension(app);

--- a/dotrix_pbr/src/light.rs
+++ b/dotrix_pbr/src/light.rs
@@ -150,8 +150,8 @@ pub fn startup(mut globals: Mut<Globals>) {
     globals.set(Lights::default());
 }
 
-/// Lights binding system
-pub fn bind(
+/// Lights loading system
+pub fn load(
     world: Const<World>,
     renderer: Const<Renderer>,
     mut globals: Mut<Globals>,


### PR DESCRIPTION
- Rename camera `bind` system to `load` to change the run level
- Set lowest priority for the system to be executed before rendering
closes #121 