### PR TITLE
Add method to query components for specific entity

### DIFF
--- a/dotrix_core/src/assets.rs
+++ b/dotrix_core/src/assets.rs
@@ -139,7 +139,7 @@ impl Assets {
     /// use dotrix_core::{
     ///     assets::Texture,
     ///     ecs::Mut,
-    ///     services::Assets,
+    ///     Assets,
     /// };
     ///
     /// fn my_system(mut assets: Mut<Assets>) {


### PR DESCRIPTION
This PR:

- Adds new `World::get` method to query components for specific entity
- Adds return value for `spawn` method with slice of spawned Entity IDs
- Adds unit test for new functionality
- Fixes `use` in documentation blocks