### PR TITLE
Window resizing and new run level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ name = "dotrix_egui"
 version = "0.5.0"
 dependencies = [
  "dotrix_core",
+ "dotrix_math",
  "dotrix_overlay",
  "egui",
 ]
@@ -2451,12 +2452,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70466a5f4825cc88c92963591b06dbc255420bffe19d847bfcda475e82d079c0"
+checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 dependencies = [
  "bitflags",
- "block",
  "cocoa",
  "core-foundation 0.9.2",
  "core-graphics 0.22.3",

--- a/dotrix_core/Cargo.toml
+++ b/dotrix_core/Cargo.toml
@@ -55,7 +55,7 @@ features = ["trace"]
 version = "0.1.0"
 
 [dependencies.winit]
-version = "0.26.0"
+version = "0.26.1"
 features = ["serde"]
 
 # Optional dependencies

--- a/dotrix_core/src/application.rs
+++ b/dotrix_core/src/application.rs
@@ -161,6 +161,7 @@ fn run(
                 scheduler.run_update(&mut services, current_state_ptr);
                 scheduler.run_load(&mut services, current_state_ptr);
                 scheduler.run_compute(&mut services, current_state_ptr);
+                scheduler.run_pre_render(&mut services, current_state_ptr);
                 scheduler.run_render(&mut services, current_state_ptr);
                 scheduler.run_release(&mut services, current_state_ptr);
             }
@@ -205,6 +206,7 @@ struct Scheduler {
     update: Vec<Box<dyn Systemized>>,
     load: Vec<Box<dyn Systemized>>,
     compute: Vec<Box<dyn Systemized>>,
+    pre_render: Vec<Box<dyn Systemized>>,
     render: Vec<Box<dyn Systemized>>,
     release: Vec<Box<dyn Systemized>>,
     resize: Vec<Box<dyn Systemized>>,
@@ -218,6 +220,7 @@ impl Scheduler {
             update: Vec::new(),
             load: Vec::new(),
             compute: Vec::new(),
+            pre_render: Vec::new(),
             render: Vec::new(),
             release: Vec::new(),
             resize: Vec::new(),
@@ -233,6 +236,7 @@ impl Scheduler {
             RunLevel::Update => &mut self.update,
             RunLevel::Load => &mut self.load,
             RunLevel::Compute => &mut self.compute,
+            RunLevel::PreRender => &mut self.pre_render,
             RunLevel::Render => &mut self.render,
             RunLevel::Release => &mut self.release,
             RunLevel::Resize => &mut self.resize,
@@ -271,6 +275,10 @@ impl Scheduler {
 
     pub fn run_compute(&mut self, services: &mut Services, state_ptr: *const Id<State>) {
         Self::run(&mut self.compute, services, state_ptr);
+    }
+
+    pub fn run_pre_render(&mut self, services: &mut Services, state_ptr: *const Id<State>) {
+        Self::run(&mut self.pre_render, services, state_ptr);
     }
 
     pub fn run_render(&mut self, services: &mut Services, state_ptr: *const Id<State>) {

--- a/dotrix_core/src/application.rs
+++ b/dotrix_core/src/application.rs
@@ -15,7 +15,7 @@ use crate::{Assets, Id, Input, State, Window};
 
 /// Application data to maintain the process
 ///
-/// Do not construct it manually, use [`crate::Dotrix`] instead
+/// Do not construct it manually, use Dotrix instead
 pub struct Application {
     name: &'static str,
     scheduler: Scheduler,
@@ -74,8 +74,6 @@ impl<T: IntoService> Service<T> {
 }
 
 /// Service abstraction
-///
-/// More info about [`crate::services`]
 pub trait IntoService: Sized + Send + Sync + 'static {
     /// Constructs wrapped service
     fn service(self) -> Service<Self> {
@@ -128,6 +126,15 @@ fn run(
 
         if let Some(assets) = services.get_mut::<Assets>() {
             assets.fetch();
+        }
+
+        let resize_requested = services
+            .get_mut::<Window>()
+            .map(|window| window.resize())
+            .unwrap_or(false);
+
+        if resize_requested {
+            scheduler.run_resize(&mut services, current_state_ptr);
         }
 
         match event {

--- a/dotrix_core/src/ecs.rs
+++ b/dotrix_core/src/ecs.rs
@@ -65,6 +65,8 @@ pub enum RunLevel {
     Load,
     /// Execution on every frame to submit compute passes
     Compute,
+    /// Execution on every frame to pre-render to textures
+    PreRender,
     /// Execution on every frame to submit rendering passes
     Render,
     /// Execution everytime after a frame was rendered
@@ -83,6 +85,8 @@ impl From<&str> for RunLevel {
             RunLevel::Load
         } else if name.ends_with("::compute") {
             RunLevel::Compute
+        } else if name.ends_with("::prerender") {
+            RunLevel::PreRender
         } else if name.ends_with("::render") {
             RunLevel::Render
         } else if name.ends_with("::release") {

--- a/dotrix_core/src/renderer.rs
+++ b/dotrix_core/src/renderer.rs
@@ -9,7 +9,7 @@ mod sampler;
 mod shader;
 mod texture;
 
-use dotrix_math::Mat4;
+use dotrix_math::{Mat4, Vec2};
 
 use crate::assets::{Mesh, Shader};
 use crate::ecs::{Const, Mut};
@@ -163,6 +163,12 @@ impl Renderer {
         self.context_mut()
             .run_compute_pipeline(pipeline.shader, &pipeline.bindings, args);
     }
+
+    /// Returns surface size
+    pub fn surface_size(&self) -> Vec2 {
+        let ctx = self.context();
+        Vec2::new(ctx.sur_desc.width as f32, ctx.sur_desc.height as f32)
+    }
 }
 
 /// Antialiasing modes enumeration
@@ -228,6 +234,7 @@ pub fn startup(mut renderer: Mut<Renderer>, mut globals: Mut<Globals>, window: M
 pub fn bind(mut renderer: Mut<Renderer>, mut assets: Mut<Assets>) {
     let clear_color = renderer.clear_color;
     let sample_count = renderer.antialiasing.sample_count();
+
     // NOTE: other option here is to check sample_count != context.sample_count
     let reload_request = renderer
         .context_mut()

--- a/dotrix_core/src/renderer/pipelines.rs
+++ b/dotrix_core/src/renderer/pipelines.rs
@@ -62,6 +62,7 @@ impl Pipeline {
 }
 
 /// Scissors Rectangle
+#[derive(Debug, Clone, Copy)]
 pub struct ScissorsRect {
     /// Minimal clip size by X axis
     pub clip_min_x: u32,
@@ -74,6 +75,7 @@ pub struct ScissorsRect {
 }
 
 /// Draw call arguments
+#[derive(Debug, Clone, Copy)]
 pub struct DrawArgs {
     /// Scissors Rectangle
     pub scissors_rect: Option<ScissorsRect>,

--- a/dotrix_core/src/window.rs
+++ b/dotrix_core/src/window.rs
@@ -74,6 +74,7 @@ pub struct Window {
     title: String,
     /// winit window instance
     window: Option<winit::window::Window>,
+    resize_request: Option<Vec2u>,
 }
 
 impl Default for Window {
@@ -90,6 +91,7 @@ impl Default for Window {
             monitors: Vec::with_capacity(2),
             title: String::from("Dotrix"),
             window: None,
+            resize_request: None,
         }
     }
 }
@@ -408,14 +410,23 @@ impl Window {
         }
     }
 
-    /// Modifies the inner size of the window.
+    /// Requests the window to change its inner size
     ///
+    /// The change takes an effect only for the next rendering frame
     /// See `inner_size` for more information about the values. This automatically
     /// un-maximizes the window if it's maximized.
-    pub fn set_inner_size(&self, size: Vec2u) {
-        let width = clamp_min(size.x, self.min_inner_size.x);
-        let height = clamp_min(size.y, self.min_inner_size.y);
-        self.get().set_inner_size(PhysicalSize::new(width, height));
+    pub fn set_inner_size(&mut self, size: Vec2u) {
+        self.resize_request = Some(size);
+    }
+
+    pub(crate) fn resize(&mut self) -> bool {
+        if let Some(size) = self.resize_request.take() {
+            let width = clamp_min(size.x, self.min_inner_size.x);
+            let height = clamp_min(size.y, self.min_inner_size.y);
+            self.get().set_inner_size(PhysicalSize::new(width, height));
+            return true;
+        }
+        false
     }
 
     /// Sets the window to maximized or back.

--- a/dotrix_core/src/world.rs
+++ b/dotrix_core/src/world.rs
@@ -35,7 +35,7 @@ impl World {
 
     /// Spawn single or multiple entities in the world
     ///
-    /// Entity appears only when you spawn it in the [`World`] as a tuple of [`crate::components`].
+    /// Entity appears only when you spawn it in the [`World`] as a tuple of components.
     ///
     /// ```no_run
     /// use dotrix_core::{

--- a/dotrix_egui/Cargo.toml
+++ b/dotrix_egui/Cargo.toml
@@ -17,5 +17,9 @@ path = "../dotrix_core"
 version = "0.1"
 path = "../dotrix_overlay"
 
+[dependencies.dotrix_math]
+version = "0.4"
+path = "../dotrix_math"
+
 [dependencies.egui]
 version = "0.16.1"


### PR DESCRIPTION
This PR will:

- Add default traits implementation to data strutures
- Switch to use renderer's surface size instead of window's size for scissors rectangle calculation
- Switch from direct window resize to resize request
- Update winit dependency
- Add `RunLevel::PreRender` to ECS and Scheduler

Closes #118 