### PR TITLE
Feat/texture updates

### DIFF
--- a/dotrix_core/src/assets/mesh.rs
+++ b/dotrix_core/src/assets/mesh.rs
@@ -354,7 +354,7 @@ mod tests {
             [-width, width, width],
         ];
 
-        width = width / 2.0;
+        width /= 2.0;
 
         let verticies_test_original_2: Vec<[f32; 3]> = vec![
             [-width, -width, -width],
@@ -367,7 +367,7 @@ mod tests {
             [-width, width, width],
         ];
 
-        width = width / 2.0;
+        width /= 2.0;
 
         let verticies_test_original_3: Vec<[u32; 3]> = vec![
             [-width as u32, -width as u32, -width as u32],

--- a/dotrix_core/src/assets/shader.rs
+++ b/dotrix_core/src/assets/shader.rs
@@ -16,6 +16,7 @@ impl Shader {
     /// Loads the shader to GPU
     pub fn load(&mut self, renderer: &Renderer) {
         if !self.module.loaded() {
+            self.module.label = self.name.clone();
             renderer.load_shader(&mut self.module, &self.code);
         }
     }

--- a/dotrix_core/src/assets/texture.rs
+++ b/dotrix_core/src/assets/texture.rs
@@ -45,4 +45,17 @@ impl Texture {
     pub fn unload(&mut self) {
         self.buffer.unload();
     }
+
+    /// Fetch data from the gpu
+    ///
+    /// This is useful textures that are altered on the gpu
+    ///
+    /// This operation is slow and should mostly be
+    /// used for debugging
+    pub fn fetch_from_gpu(
+        &mut self,
+        renderer: &mut Renderer,
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, wgpu::BufferAsyncError>> {
+        renderer.fetch_texture(&self.buffer, [self.width, self.height, self.depth])
+    }
 }

--- a/dotrix_core/src/cubemap.rs
+++ b/dotrix_core/src/cubemap.rs
@@ -32,7 +32,7 @@ impl Default for CubeMap {
             bottom: Id::default(),
             back: Id::default(),
             front: Id::default(),
-            buffer: TextureBuffer::new("CubeMap Texture Buffer"),
+            buffer: TextureBuffer::new_cube("CubeMap Texture Buffer"),
         }
     }
 }

--- a/dotrix_core/src/renderer.rs
+++ b/dotrix_core/src/renderer.rs
@@ -84,7 +84,9 @@ impl Renderer {
         buffer.load(self.context(), attributes, indices, count as u32);
     }*/
 
-    /// Loads the texture buffer to GPU
+    /// Loads the texture buffer to GPU.
+    /// This will recreate the texture, as a result it must be rebound on any pipelines for changes
+    /// to take effect
     pub fn load_texture<'a>(
         &self,
         texture: &mut Texture,
@@ -93,6 +95,32 @@ impl Renderer {
         layers: &'a [&'a [u8]],
     ) {
         texture.load(self.context(), width, height, layers);
+    }
+
+    /// Load data from cpu to a texture buffer on GPU
+    /// This is a noop if texture has not been loaded with `load_texture`
+    /// Unexpected results/errors occur if the dimensions differs from it dimensions at load time
+    pub fn update_texture<'a>(
+        &self,
+        texture: &mut Texture,
+        width: u32,
+        height: u32,
+        layers: &'a [&'a [u8]],
+    ) {
+        texture.update(self.context(), width, height, layers);
+    }
+
+    /// This will `[update_texture]` if texture has been loaded or `[load_texture]` if not
+    /// the same cavets of `[update_texture]` apply in that care must be taken not to change
+    /// the dimensions between `load` and `update`
+    pub fn update_or_load_texture<'a>(
+        &self,
+        texture: &mut Texture,
+        width: u32,
+        height: u32,
+        layers: &'a [&'a [u8]],
+    ) {
+        texture.update_or_load(self.context(), width, height, layers);
     }
 
     /// Loads the buffer to GPU

--- a/dotrix_core/src/renderer/bindings.rs
+++ b/dotrix_core/src/renderer/bindings.rs
@@ -76,9 +76,7 @@ impl<'a> BindGroup<'a> {
                     visibility: stage.into(),
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
-                        sample_type: wgpu::TextureSampleType::Float {
-                            filterable: texture.is_filterable(),
-                        },
+                        sample_type: texture.sample_type(),
                         view_dimension: wgpu::TextureViewDimension::D2,
                     },
                     count: None,
@@ -88,9 +86,7 @@ impl<'a> BindGroup<'a> {
                     visibility: stage.into(),
                     ty: wgpu::BindingType::Texture {
                         multisampled: false,
-                        sample_type: wgpu::TextureSampleType::Float {
-                            filterable: texture.is_filterable(),
-                        },
+                        sample_type: texture.sample_type(),
                         view_dimension: wgpu::TextureViewDimension::Cube,
                     },
                     count: None,

--- a/dotrix_core/src/renderer/bindings.rs
+++ b/dotrix_core/src/renderer/bindings.rs
@@ -32,12 +32,16 @@ pub enum Binding<'a> {
     Texture(&'a str, Stage, &'a Texture),
     /// Cube Texture binding
     TextureCube(&'a str, Stage, &'a Texture),
+    /// 2D Texture Array binding
+    TextureArray(&'a str, Stage, &'a Texture),
     /// 3D Texture binding
     Texture3D(&'a str, Stage, &'a Texture),
     /// Storage texture binding
     StorageTexture(&'a str, Stage, &'a Texture, Access),
     /// Storage texture cube binding
     StorageTextureCube(&'a str, Stage, &'a Texture, Access),
+    /// Storage 2D texture array binding
+    StorageTextureArray(&'a str, Stage, &'a Texture, Access),
     /// Storage texture binding 3D
     StorageTexture3D(&'a str, Stage, &'a Texture, Access),
     /// Texture sampler binding
@@ -97,6 +101,16 @@ impl<'a> BindGroup<'a> {
                     },
                     count: None,
                 },
+                Binding::TextureArray(_, stage, texture) => wgpu::BindGroupLayoutEntry {
+                    binding: index as u32,
+                    visibility: stage.into(),
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: texture.sample_type(),
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
+                    },
+                    count: None,
+                },
                 Binding::Texture3D(_, stage, texture) => wgpu::BindGroupLayoutEntry {
                     binding: index as u32,
                     visibility: stage.into(),
@@ -125,6 +139,18 @@ impl<'a> BindGroup<'a> {
                             access: access.into(),
                             format: texture.format,
                             view_dimension: wgpu::TextureViewDimension::Cube,
+                        },
+                        count: None,
+                    }
+                }
+                Binding::StorageTextureArray(_, stage, texture, access) => {
+                    wgpu::BindGroupLayoutEntry {
+                        binding: index as u32,
+                        visibility: stage.into(),
+                        ty: wgpu::BindingType::StorageTexture {
+                            access: access.into(),
+                            format: texture.format,
+                            view_dimension: wgpu::TextureViewDimension::D2Array,
                         },
                         count: None,
                     }
@@ -206,9 +232,11 @@ impl Bindings {
                                 }
                                 Binding::Texture(_, _, texture)
                                 | Binding::TextureCube(_, _, texture)
+                                | Binding::TextureArray(_, _, texture)
                                 | Binding::Texture3D(_, _, texture)
                                 | Binding::StorageTexture(_, _, texture, _)
                                 | Binding::StorageTextureCube(_, _, texture, _)
+                                | Binding::StorageTextureArray(_, _, texture, _)
                                 | Binding::StorageTexture3D(_, _, texture, _) => {
                                     wgpu::BindingResource::TextureView(texture.get())
                                 }

--- a/dotrix_core/src/renderer/bindings.rs
+++ b/dotrix_core/src/renderer/bindings.rs
@@ -30,10 +30,12 @@ pub enum Binding<'a> {
     Uniform(&'a str, Stage, &'a Buffer),
     /// Texture binding
     Texture(&'a str, Stage, &'a Texture),
-    /// 3D Texture binding
-    Texture3D(&'a str, Stage, &'a Texture),
+    /// Cube Texture binding
+    TextureCube(&'a str, Stage, &'a Texture),
     /// Storage texture binding
     StorageTexture(&'a str, Stage, &'a Texture, Access),
+    /// Storage texture cube binding
+    StorageTextureCube(&'a str, Stage, &'a Texture, Access),
     /// Texture sampler binding
     Sampler(&'a str, Stage, &'a Sampler),
     /// Storage binding
@@ -81,7 +83,7 @@ impl<'a> BindGroup<'a> {
                     },
                     count: None,
                 },
-                Binding::Texture3D(_, stage, texture) => wgpu::BindGroupLayoutEntry {
+                Binding::TextureCube(_, stage, texture) => wgpu::BindGroupLayoutEntry {
                     binding: index as u32,
                     visibility: stage.into(),
                     ty: wgpu::BindingType::Texture {
@@ -101,6 +103,18 @@ impl<'a> BindGroup<'a> {
                     },
                     count: None,
                 },
+                Binding::StorageTextureCube(_, stage, texture, access) => {
+                    wgpu::BindGroupLayoutEntry {
+                        binding: index as u32,
+                        visibility: stage.into(),
+                        ty: wgpu::BindingType::StorageTexture {
+                            access: access.into(),
+                            format: texture.format,
+                            view_dimension: wgpu::TextureViewDimension::Cube,
+                        },
+                        count: None,
+                    }
+                }
                 Binding::Sampler(_, stage, _) => wgpu::BindGroupLayoutEntry {
                     binding: index as u32,
                     visibility: stage.into(),
@@ -165,8 +179,9 @@ impl Bindings {
                                     uniform.get().as_entire_binding()
                                 }
                                 Binding::Texture(_, _, texture)
-                                | Binding::Texture3D(_, _, texture)
-                                | Binding::StorageTexture(_, _, texture, _) => {
+                                | Binding::TextureCube(_, _, texture)
+                                | Binding::StorageTexture(_, _, texture, _)
+                                | Binding::StorageTextureCube(_, _, texture, _) => {
                                     wgpu::BindingResource::TextureView(texture.get())
                                 }
                                 Binding::Sampler(_, _, sampler) => {

--- a/dotrix_core/src/renderer/bindings.rs
+++ b/dotrix_core/src/renderer/bindings.rs
@@ -32,10 +32,14 @@ pub enum Binding<'a> {
     Texture(&'a str, Stage, &'a Texture),
     /// Cube Texture binding
     TextureCube(&'a str, Stage, &'a Texture),
+    /// 3D Texture binding
+    Texture3D(&'a str, Stage, &'a Texture),
     /// Storage texture binding
     StorageTexture(&'a str, Stage, &'a Texture, Access),
     /// Storage texture cube binding
     StorageTextureCube(&'a str, Stage, &'a Texture, Access),
+    /// Storage texture binding 3D
+    StorageTexture3D(&'a str, Stage, &'a Texture, Access),
     /// Texture sampler binding
     Sampler(&'a str, Stage, &'a Sampler),
     /// Storage binding
@@ -93,6 +97,16 @@ impl<'a> BindGroup<'a> {
                     },
                     count: None,
                 },
+                Binding::Texture3D(_, stage, texture) => wgpu::BindGroupLayoutEntry {
+                    binding: index as u32,
+                    visibility: stage.into(),
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: texture.sample_type(),
+                        view_dimension: wgpu::TextureViewDimension::D3,
+                    },
+                    count: None,
+                },
                 Binding::StorageTexture(_, stage, texture, access) => wgpu::BindGroupLayoutEntry {
                     binding: index as u32,
                     visibility: stage.into(),
@@ -111,6 +125,18 @@ impl<'a> BindGroup<'a> {
                             access: access.into(),
                             format: texture.format,
                             view_dimension: wgpu::TextureViewDimension::Cube,
+                        },
+                        count: None,
+                    }
+                }
+                Binding::StorageTexture3D(_, stage, texture, access) => {
+                    wgpu::BindGroupLayoutEntry {
+                        binding: index as u32,
+                        visibility: stage.into(),
+                        ty: wgpu::BindingType::StorageTexture {
+                            access: access.into(),
+                            format: texture.format,
+                            view_dimension: wgpu::TextureViewDimension::D3,
                         },
                         count: None,
                     }
@@ -180,8 +206,10 @@ impl Bindings {
                                 }
                                 Binding::Texture(_, _, texture)
                                 | Binding::TextureCube(_, _, texture)
+                                | Binding::Texture3D(_, _, texture)
                                 | Binding::StorageTexture(_, _, texture, _)
-                                | Binding::StorageTextureCube(_, _, texture, _) => {
+                                | Binding::StorageTextureCube(_, _, texture, _)
+                                | Binding::StorageTexture3D(_, _, texture, _) => {
                                     wgpu::BindingResource::TextureView(texture.get())
                                 }
                                 Binding::Sampler(_, _, sampler) => {

--- a/dotrix_core/src/renderer/buffer.rs
+++ b/dotrix_core/src/renderer/buffer.rs
@@ -47,6 +47,16 @@ impl Buffer {
         Self::new(label).use_as_indirect()
     }
 
+    /// Construct new Map Read buffer
+    pub fn map_read(label: &str) -> Self {
+        Self::new(label).use_as_map_read()
+    }
+
+    /// Construct new Map Write buffer
+    pub fn map_write(label: &str) -> Self {
+        Self::new(label).use_as_map_write()
+    }
+
     /// Allow to use as Vertex Buffer
     #[must_use]
     pub fn use_as_vertex(mut self) -> Self {
@@ -82,6 +92,20 @@ impl Buffer {
         self
     }
 
+    /// Allow to use as Map Read Buffer
+    #[must_use]
+    pub fn use_as_map_read(mut self) -> Self {
+        self.usage |= wgpu::BufferUsages::MAP_READ;
+        self
+    }
+
+    /// Allow to use as Map Write Buffer
+    #[must_use]
+    pub fn use_as_map_write(mut self) -> Self {
+        self.usage |= wgpu::BufferUsages::MAP_WRITE;
+        self
+    }
+
     /// Allow reading from buffer
     #[must_use]
     pub fn allow_read(mut self) -> Self {
@@ -114,6 +138,18 @@ impl Buffer {
                 },
             ));
         }
+    }
+
+    /// Create buffer of size without data
+    ///
+    /// Typically used for staging buffers
+    pub fn create(&mut self, ctx: &Context, size: u32, mapped: bool) {
+        self.wgpu_buffer = Some(ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(self.label.as_str()),
+            size: size as wgpu::BufferAddress,
+            usage: self.usage,
+            mapped_at_creation: mapped,
+        }));
     }
 
     /// Check if buffer isloaded

--- a/dotrix_core/src/renderer/texture.rs
+++ b/dotrix_core/src/renderer/texture.rs
@@ -278,6 +278,7 @@ impl Texture {
 
     /// Release all resources used by the texture
     pub fn unload(&mut self) {
+        self.wgpu_texture.take();
         self.wgpu_texture_view.take();
     }
 

--- a/dotrix_core/src/renderer/texture.rs
+++ b/dotrix_core/src/renderer/texture.rs
@@ -145,6 +145,12 @@ impl Texture {
     }
 
     /// Loads data into the texture buffer
+    ///
+    /// This will recreate the texture backend on the gpu. Which means it must be rebound
+    /// in the pipelines for changes to take effect.
+    ///
+    /// If you want to update the values without recreating and therefore rebinding the texture
+    /// see `[update]`
     pub(crate) fn load<'a>(&mut self, ctx: &Context, width: u32, height: u32, layers: &[&'a [u8]]) {
         let dimension = match self.kind {
             TextureKind::D2 => wgpu::TextureViewDimension::D2,
@@ -164,10 +170,7 @@ impl Texture {
             height,
             depth_or_array_layers,
         };
-        let layer_size = wgpu::Extent3d {
-            depth_or_array_layers: 1,
-            ..size
-        };
+
         let max_mips = 1;
 
         let tex_dimension: wgpu::TextureDimension = match self.kind {
@@ -194,30 +197,78 @@ impl Texture {
             ..wgpu::TextureViewDescriptor::default()
         }));
 
-        for (i, data) in layers.iter().enumerate() {
-            let bytes_per_row = std::num::NonZeroU32::new(data.len() as u32 / height).unwrap();
-            ctx.queue.write_texture(
-                wgpu::ImageCopyTexture {
-                    texture: &texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: 0,
-                        y: 0,
-                        z: i as u32,
-                    },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                data,
-                wgpu::ImageDataLayout {
-                    offset: 0,
-                    bytes_per_row: Some(bytes_per_row),
-                    rows_per_image: Some(std::num::NonZeroU32::new(height).unwrap()),
-                },
-                layer_size,
-            );
-        }
-
         self.wgpu_texture = Some(texture);
+
+        self.update(ctx, width, height, layers)
+    }
+
+    /// This will write to a texture but not create it
+    /// This can be used to update a texture's value with out recreating and therefore without the
+    /// need to rebind it
+    /// however if the size of the texture is changed it will behave oddly or even panic
+    ///
+    /// This is a no op if the texture has not been loaded
+    pub(crate) fn update<'a>(
+        &mut self,
+        ctx: &Context,
+        width: u32,
+        height: u32,
+        layers: &[&'a [u8]],
+    ) {
+        if let Some(texture) = self.wgpu_texture.as_ref() {
+            let depth_or_array_layers = layers.len() as u32;
+            let size = wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers,
+            };
+            let layer_size = wgpu::Extent3d {
+                depth_or_array_layers: 1,
+                ..size
+            };
+
+            for (i, data) in layers.iter().enumerate() {
+                let bytes_per_row = std::num::NonZeroU32::new(data.len() as u32 / height).unwrap();
+                ctx.queue.write_texture(
+                    wgpu::ImageCopyTexture {
+                        texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: 0,
+                            y: 0,
+                            z: i as u32,
+                        },
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    data,
+                    wgpu::ImageDataLayout {
+                        offset: 0,
+                        bytes_per_row: Some(bytes_per_row),
+                        rows_per_image: Some(std::num::NonZeroU32::new(height).unwrap()),
+                    },
+                    layer_size,
+                );
+            }
+        }
+    }
+
+    /// This method will update a gpu texture if it exists with new data or
+    /// load a new texture onto the gpu if it does not.
+    ///
+    /// The same cavets of [`update`] apply in that care must be taken to not
+    /// change the size of the texture between [`load`] and [`update`]
+    pub(crate) fn update_or_load<'a>(
+        &mut self,
+        ctx: &Context,
+        width: u32,
+        height: u32,
+        layers: &[&'a [u8]],
+    ) {
+        if self.wgpu_texture.is_none() {
+            self.load(ctx, width, height, layers);
+        } else {
+            self.update(ctx, width, height, layers);
+        }
     }
 
     /// Checks if texture is loaded

--- a/dotrix_core/src/renderer/texture.rs
+++ b/dotrix_core/src/renderer/texture.rs
@@ -4,6 +4,7 @@ use wgpu;
 pub enum TextureKind {
     D2,
     Cube,
+    D2Array,
     D3,
 }
 
@@ -52,6 +53,16 @@ impl Texture {
             label: String::from(label),
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             kind: TextureKind::Cube,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a 2D Array GPU Texture
+    pub fn new_array(label: &str) -> Self {
+        Self {
+            label: String::from(label),
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            kind: TextureKind::D2Array,
             ..Default::default()
         }
     }
@@ -141,6 +152,7 @@ impl Texture {
                 assert!(layers.len() == 6);
                 wgpu::TextureViewDimension::Cube
             }
+            TextureKind::D2Array => wgpu::TextureViewDimension::D2Array,
             TextureKind::D3 => wgpu::TextureViewDimension::D3,
         };
 
@@ -161,6 +173,7 @@ impl Texture {
         let tex_dimension: wgpu::TextureDimension = match self.kind {
             TextureKind::D2 => wgpu::TextureDimension::D2,
             TextureKind::Cube => wgpu::TextureDimension::D2,
+            TextureKind::D2Array => wgpu::TextureDimension::D2,
             TextureKind::D3 => wgpu::TextureDimension::D3,
         };
 

--- a/dotrix_core/src/renderer/texture.rs
+++ b/dotrix_core/src/renderer/texture.rs
@@ -4,6 +4,7 @@ use wgpu;
 pub enum TextureKind {
     D2,
     Cube,
+    D3,
 }
 
 /// GPU Texture Implementation
@@ -51,6 +52,16 @@ impl Texture {
             label: String::from(label),
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             kind: TextureKind::Cube,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a 3D GPU Texture
+    pub fn new_3d(label: &str) -> Self {
+        Self {
+            label: String::from(label),
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            kind: TextureKind::D3,
             ..Default::default()
         }
     }
@@ -130,6 +141,7 @@ impl Texture {
                 assert!(layers.len() == 6);
                 wgpu::TextureViewDimension::Cube
             }
+            TextureKind::D3 => wgpu::TextureViewDimension::D3,
         };
 
         let format = self.format;
@@ -149,6 +161,7 @@ impl Texture {
         let tex_dimension: wgpu::TextureDimension = match self.kind {
             TextureKind::D2 => wgpu::TextureDimension::D2,
             TextureKind::Cube => wgpu::TextureDimension::D2,
+            TextureKind::D3 => wgpu::TextureDimension::D3,
         };
 
         let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {

--- a/dotrix_core/src/world.rs
+++ b/dotrix_core/src/world.rs
@@ -604,7 +604,7 @@ mod tests {
         let world = spawn();
         let entity = Entity::from(0);
         let query = world.get::<(&Armor, &Health)>(entity);
-        assert_eq!(query.is_some(), true);
+        assert!(query.is_some());
         if let Some((&armor, &health)) = query {
             assert_eq!(armor, Armor(100));
             assert_eq!(health, Health(100));
@@ -630,8 +630,8 @@ mod tests {
 
         assert_eq!(spawned.len(), 3);
 
-        for i in 0..3 {
-            assert_eq!(spawned[i], Entity::from(i as u64 + 1));
+        for (i, ent) in spawned.iter().enumerate() {
+            assert_eq!(ent, &Entity::from(i as u64 + 1));
         }
     }
 }

--- a/dotrix_sky/src/skybox.rs
+++ b/dotrix_sky/src/skybox.rs
@@ -160,7 +160,7 @@ pub fn render(
                             ),
                             BindGroup::new(
                                 "Locals",
-                                vec![Binding::Texture3D(
+                                vec![Binding::TextureCube(
                                     "CubeMap",
                                     Stage::Fragment,
                                     &cubemap.buffer,

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -184,10 +184,7 @@ fn compute(
                                 Binding::Storage("Particles", Stage::Compute, &spawner.particles),
                             ],
                         )],
-                        options: ComputeOptions {
-                            cs_main: "main",
-                            ..Default::default()
-                        },
+                        options: ComputeOptions { cs_main: "main" },
                     },
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ impl Dotrix {
         }
     }
 
+    #[must_use]
     /// Adds system, service or extension to the application
     pub fn with<T>(mut self, engine_unit: T) -> Self
     where
@@ -137,14 +138,15 @@ impl Dotrix {
         self
     }
 
+    #[must_use]
     /// Adds a system to the application
     pub fn with_system(mut self, system: System) -> Self {
         self.app.as_mut().unwrap().add_system(system);
         self
     }
 
+    #[must_use]
     /// Adds a service to the application
-
     pub fn with_service<T: IntoService>(mut self, service: T) -> Self {
         self.app.as_mut().unwrap().add_service(service);
         self


### PR DESCRIPTION
This adds features from #152 that I am adding here to make the PRs more modular

Specifically:

- Adds methods to copy data from a gpu texture to an array on the cpu, (useful for debugging)
- Changes binding of Texture3D to TextureCube which represents its actual backing data
- Adds actual Texture3D bindings
- Add 2D Texture array binding
- Add a method to update the values in a texture without recreating it
  - This is needed to perform live updates of textures without having to rebind the pipeline (this is used in #152 to make voxels more easily and quickly changed on the gpu)
- Some clippy fixes
- Sets name on the shader, useful for debugging