### PR TITLE
Seperate shader

### DIFF
--- a/dotrix_core/src/assets.rs
+++ b/dotrix_core/src/assets.rs
@@ -18,12 +18,12 @@ pub use texture::*;
 
 use std::{
     any::{Any, TypeId},
-    collections::{hash_map, hash_set, HashMap, HashSet},
+    collections::{hash_map, HashMap, HashSet},
     sync::{mpsc, Arc, Mutex},
     vec::Vec,
 };
 
-use crate::{ecs::Mut, id::Id, Renderer};
+use crate::id::Id;
 
 const THREADS_COUNT: usize = 4;
 
@@ -72,8 +72,6 @@ pub struct Assets {
     sender: mpsc::Sender<Request>,
     receiver: mpsc::Receiver<Response>,
     id_generator: u64,
-    removed_assets: HashMap<TypeId, Box<dyn AssetSet>>,
-    hot_reload: bool,
     root: std::path::PathBuf,
 }
 
@@ -104,8 +102,6 @@ impl Assets {
             sender,
             receiver,
             id_generator: 1,
-            removed_assets: HashMap::new(),
-            hot_reload: true,
             root,
         }
     }
@@ -222,7 +218,6 @@ impl Assets {
     where
         Self: AssetMapGetter<T>,
     {
-        self.map_removed_mut().insert(handle);
         self.map_mut().remove(&handle)
     }
 
@@ -242,30 +237,6 @@ impl Assets {
         Self: AssetMapGetter<T>,
     {
         self.map_mut().iter_mut()
-    }
-
-    /// Returns an iter to the removed asset list
-    pub fn iter_removed<T: Asset>(&mut self) -> hash_set::Iter<'_, Id<T>>
-    where
-        Self: AssetMapGetter<T>,
-    {
-        self.map_removed_mut().iter()
-    }
-
-    /// Returns the removed asset list
-    pub fn get_removed_ref<T: Asset>(&mut self) -> Option<&HashSet<Id<T>>>
-    where
-        Self: AssetMapGetter<T>,
-    {
-        self.map_removed()
-    }
-
-    /// Returns the mutable removed asset list
-    pub fn get_removed_mut<T: Asset>(&mut self) -> &mut HashSet<Id<T>>
-    where
-        Self: AssetMapGetter<T>,
-    {
-        self.map_removed_mut()
     }
 
     fn next_id(&mut self) -> u64 {
@@ -295,43 +266,6 @@ impl Assets {
             };
         }
     }
-
-    /// Enable/Disable hot reload of certain assets. If this is
-    /// disabled certain assets like `Shaders` need to be
-    /// cleaned up manually with `renderer.drop_pipeline`
-    pub fn hot_reload_enable(&mut self, enable: bool) {
-        self.hot_reload = enable;
-    }
-}
-
-/// Reload assets and cleanup any assets that need some post process
-/// after `assets.remove`
-pub fn release(mut assets: Mut<Assets>, mut renderer: Mut<Renderer>) {
-    if !assets.hot_reload {
-        return;
-    }
-    // Shaders that no longer exist need to be removed from the renderer
-    // by dropping their pipeline
-    for removed_shader in assets
-        .iter_removed::<Shader>()
-        .copied()
-        .collect::<Vec<Id<Shader>>>()
-    {
-        if assets.get::<Shader>(removed_shader).is_none() {
-            renderer.drop_pipeline(removed_shader);
-        }
-    }
-    // assets.get_removed_mut::<Shader>().clear();
-    // TODO: Find a better way to cleanup deleted assets
-    assets.removed_assets.clear();
-
-    // Any shader that has its shader module dropped/uninitalised should have it's
-    // pipeline dropped from the renderer
-    for (id, shader) in assets.iter::<Shader>() {
-        if !shader.loaded() {
-            renderer.drop_pipeline(*id);
-        }
-    }
 }
 
 /// Asset map getting trait
@@ -343,13 +277,6 @@ pub trait AssetMapGetter<T> {
     fn map(&self) -> Option<&HashMap<Id<T>, T>>;
     /// Returns mutable HashMap reference for selected asset type
     fn map_mut(&mut self) -> &mut HashMap<Id<T>, T>;
-
-    /// Returns HashSet reference for selected asset type that have been removed
-    /// since last clean up
-    fn map_removed(&self) -> Option<&HashSet<Id<T>>>;
-    /// Returns mutable HashSet reference for selected asset type that have been removed
-    /// since last clean up
-    fn map_removed_mut(&mut self) -> &mut HashSet<Id<T>>;
 }
 
 impl<T: Asset> AssetMapGetter<T> for Assets {
@@ -369,23 +296,6 @@ impl<T: Asset> AssetMapGetter<T> for Assets {
             })
             .as_any_mut()
             .downcast_mut::<HashMap<Id<T>, T>>()
-            .unwrap()
-    }
-    fn map_removed(&self) -> Option<&HashSet<Id<T>>> {
-        self.removed_assets
-            .get(&TypeId::of::<T>())?
-            .as_any_ref()
-            .downcast_ref::<HashSet<Id<T>>>()
-    }
-    fn map_removed_mut(&mut self) -> &mut HashSet<Id<T>> {
-        self.removed_assets
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| {
-                let empty: HashSet<Id<T>> = Default::default();
-                Box::new(empty)
-            })
-            .as_any_mut()
-            .downcast_mut::<HashSet<Id<T>>>()
             .unwrap()
     }
 }

--- a/dotrix_core/src/renderer/pipelines.rs
+++ b/dotrix_core/src/renderer/pipelines.rs
@@ -47,12 +47,12 @@ impl Pipeline {
 
     /// Checks if rendering cycle should be performed
     pub fn cycle(&self, renderer: &Renderer) -> bool {
-        !self.disabled && self.cycle != renderer.cycle() && self.instance.is_some()
+        !self.disabled && self.cycle != renderer.cycle()
     }
 
     /// Returns true if Pipeline is ready to run
     pub fn ready(&self, renderer: &Renderer) -> bool {
-        self.reload_required(renderer) && self.bindings.loaded()
+        !self.reload_required(renderer) && self.bindings.loaded()
     }
 
     /// Check if the instance is valid and if a reload has been requested gloabally by
@@ -63,7 +63,7 @@ impl Pipeline {
             | Some(PipelineInstance::Render(RenderPipeline { last_reload, .. })) => {
                 last_reload < renderer.dirty
             }
-            _ => false,
+            _ => true,
         }
     }
 }

--- a/dotrix_overlay/src/lib.rs
+++ b/dotrix_overlay/src/lib.rs
@@ -177,10 +177,6 @@ pub fn render(
 
     for provider in overlay.providers() {
         for (widget, pipeline) in provider.tessellate() {
-            if pipeline.shader.is_null() {
-                pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-            }
-
             // check if model is disabled or already rendered
             if !pipeline.cycle(&renderer) {
                 continue;
@@ -195,7 +191,8 @@ pub fn render(
             }
 
             if !pipeline.ready(&renderer) {
-                if let Some(shader) = assets.get(pipeline.shader) {
+                let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+                if let Some(shader) = assets.get(shader_id) {
                     let sampler = globals
                         .get::<Sampler>()
                         .expect("Sampler buffer must be loaded");

--- a/dotrix_pbr/src/skeletal.rs
+++ b/dotrix_pbr/src/skeletal.rs
@@ -215,16 +215,14 @@ pub fn render(
     }
 }
 
-pub fn startup(mut assets: Mut<Assets>) {
-    let shader = include_str!("shaders/skeletal.wgsl");
-    assets.store_as(
-        Shader {
-            name: String::from(PIPELINE_LABEL),
-            code: add_pbr_to_shader(shader, 0, 2),
-            ..Default::default()
-        },
-        PIPELINE_LABEL,
-    );
+pub fn startup(mut assets: Mut<Assets>, renderer: Const<Renderer>) {
+    let mut shader = Shader {
+        name: String::from(PIPELINE_LABEL),
+        code: add_pbr_to_shader(include_str!("shaders/skeletal.wgsl"), 0, 2),
+        ..Default::default()
+    };
+    shader.load(&renderer);
+    assets.store_as(shader, PIPELINE_LABEL);
 }
 
 pub fn extension(app: &mut Application) {

--- a/dotrix_pbr/src/skeletal.rs
+++ b/dotrix_pbr/src/skeletal.rs
@@ -67,7 +67,7 @@ impl Entity {
                 rotate: self.rotate,
                 scale: self.scale,
             },
-            Pipeline::render(self.shader),
+            Pipeline::render(),
         ))
     }
 }
@@ -109,10 +109,6 @@ pub fn render(
     )>();
 
     for (model, pose, material, transform, render) in query {
-        if render.pipeline.shader.is_null() {
-            render.pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-        }
-
         // check if model is disabled or already rendered
         if !render.pipeline.cycle(&renderer) {
             continue;
@@ -136,7 +132,8 @@ pub fn render(
         let mesh = assets.get(model.mesh).unwrap();
 
         if !render.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(render.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }

--- a/dotrix_pbr/src/solid.rs
+++ b/dotrix_pbr/src/solid.rs
@@ -67,7 +67,7 @@ impl Entity {
                 rotate: self.rotate,
                 scale: self.scale,
             },
-            Pipeline::render(self.shader),
+            Pipeline::render(),
         )
     }
 
@@ -105,10 +105,6 @@ pub fn render(
 ) {
     let query = world.query::<(&mut Model, &mut Material, &mut Transform, &mut Render)>();
     for (model, material, transform, render) in query {
-        if render.pipeline.shader.is_null() {
-            render.pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-        }
-
         // check if model is disabled or already rendered
         if !render.pipeline.cycle(&renderer) {
             continue;
@@ -127,7 +123,8 @@ pub fn render(
         let mesh = assets.get(model.mesh).unwrap();
 
         if !render.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(render.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }

--- a/dotrix_pbr/src/solid.rs
+++ b/dotrix_pbr/src/solid.rs
@@ -147,6 +147,7 @@ pub fn render(
                     .get::<Lights>()
                     .expect("Lights buffer must be loaded");
 
+                println!("BIND");
                 renderer.bind(
                     &mut render.pipeline,
                     PipelineLayout::Render {
@@ -201,21 +202,19 @@ pub fn render(
             }
         }
 
+        println!("DRAW");
         renderer.draw(&mut render.pipeline, mesh, &DrawArgs::default());
     }
 }
 
-pub fn startup(mut assets: Mut<Assets>) {
-    let shader = include_str!("shaders/solid.wgsl");
-
-    assets.store_as(
-        Shader {
-            name: String::from(PIPELINE_LABEL),
-            code: add_pbr_to_shader(shader, 0, 2),
-            ..Default::default()
-        },
-        PIPELINE_LABEL,
-    );
+pub fn startup(mut assets: Mut<Assets>, renderer: Const<Renderer>) {
+    let mut shader = Shader {
+        name: String::from(PIPELINE_LABEL),
+        code: add_pbr_to_shader(include_str!("shaders/solid.wgsl"), 0, 2),
+        ..Default::default()
+    };
+    shader.load(&renderer);
+    assets.store_as(shader, PIPELINE_LABEL);
 }
 
 pub fn extension(app: &mut Application) {

--- a/dotrix_sky/src/skybox.rs
+++ b/dotrix_sky/src/skybox.rs
@@ -115,10 +115,6 @@ pub fn render(
             scale: Mat4::from_scale(scale).into(),
         };
 
-        if render.pipeline.shader.is_null() {
-            render.pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-        }
-
         // check if model is disabled or already rendered
         if !render.pipeline.cycle(&renderer) {
             continue;
@@ -139,7 +135,8 @@ pub fn render(
             .unwrap();
 
         if !render.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(render.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 let sampler = globals
                     .get::<Sampler>()
                     .expect("Sampler buffer must be loaded");

--- a/dotrix_terrain/src/systems.rs
+++ b/dotrix_terrain/src/systems.rs
@@ -232,10 +232,6 @@ pub fn render(
     let query = world.query::<(&mut Tile, &mut Material, &mut Pipeline)>();
 
     for (tile, material, pipeline) in query {
-        if pipeline.shader.is_null() {
-            pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-        }
-
         // check if model is disabled or already rendered
         if !pipeline.cycle(&renderer) {
             continue;
@@ -255,7 +251,8 @@ pub fn render(
         let mesh = assets.get(tile.mesh).unwrap();
 
         if !pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(pipeline.shader) {
+            let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -154,10 +154,6 @@ fn compute(
     mut renderer: Mut<Renderer>,
 ) {
     for (spawner, compute) in world.query::<(&mut ParticlesSpawner, &mut Compute)>() {
-        // Set the shader on the pipeline
-        if compute.pipeline.shader.is_null() {
-            compute.pipeline.shader = assets.find::<Shader>(COMPUTE_PIPELINE).unwrap_or_default();
-        }
         // update time delta
         let params = Params {
             simulation_time: frame.time().as_secs_f32(),
@@ -167,7 +163,8 @@ fn compute(
 
         // Bind the uniforms to the shader
         if !compute.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(compute.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(COMPUTE_PIPELINE).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }
@@ -212,17 +209,13 @@ fn render(
     mut renderer: Mut<Renderer>,
 ) {
     for (spawner, render) in world.query::<(&mut ParticlesSpawner, &mut Render)>() {
-        // Set the shader on the pipeline
-        if render.pipeline.shader.is_null() {
-            render.pipeline.shader = assets.find::<Shader>(RENDER_PIPELINE).unwrap_or_default();
-        }
-
         let mesh = assets
             .get(assets.find(PARTICLE_MESH).expect("Mesh must be loaded"))
             .unwrap();
 
         if !render.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(render.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(RENDER_PIPELINE).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }

--- a/examples/msaa/main.rs
+++ b/examples/msaa/main.rs
@@ -64,7 +64,7 @@ fn startup(mut camera: Mut<Camera>, mut world: Mut<World>, mut assets: Mut<Asset
             ..Default::default()
         },
         Transform::default(),
-        Pipeline::render(Id::default()),
+        Pipeline::render(),
     )]);
 
     // Spawn lights

--- a/examples/shader/shader.rs
+++ b/examples/shader/shader.rs
@@ -103,11 +103,6 @@ pub fn render(
             .get::<ProjView>()
             .expect("ProjView buffer must be loaded");
 
-        // Set the shader on the pipeline
-        if render.pipeline.shader.is_null() {
-            render.pipeline.shader = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
-        }
-
         // check if model is disabled or already rendered
         if !render.pipeline.cycle(&renderer) {
             continue;
@@ -117,7 +112,8 @@ pub fn render(
 
         // Bind the uniforms to the shader
         if !render.pipeline.ready(&renderer) {
-            if let Some(shader) = assets.get(render.pipeline.shader) {
+            let shader_id = assets.find::<Shader>(PIPELINE_LABEL).unwrap_or_default();
+            if let Some(shader) = assets.get(shader_id) {
                 if !shader.loaded() {
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,6 @@ impl Dotrix {
         // Reset input events
         app.add_system(System::from(input::release));
 
-        // Reload and clean up assets
-        app.add_system(System::from(assets::release));
-
         Self { app: Some(app) }
     }
 


### PR DESCRIPTION
This attempts to seperate Shaders from Pipelines

It also removes the need to cleanup shaders from the renderer

Note: There is now 1 pipeline instance per Pipeline object, need to see what impact that has